### PR TITLE
docs: define error handling policy and shared contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,67 @@ npm run gen:types
 npm run gen:types:prod
 ```
 
+## Error Handling Policy
+
+<details>
+<summary>Core Rules</summary>
+
+- Expected failures are returned as values and handled by the caller.
+- Unexpected failures are thrown and allowed to reach the nearest Next.js error boundary.
+- `404` cases use `notFound()` and `app/not-found.tsx`, not generic error fallback UI.
+- Error handling should stay close to the layer that can present the best user experience.
+
+</details>
+
+<details>
+<summary>Server Components</summary>
+
+- Server Components should call the service layer directly instead of calling this app's own API Routes.
+- Expected failures from the service layer should be handled with conditional rendering.
+- Missing resources should trigger `notFound()`.
+- Unexpected failures should not be converted into inline fallback values just to avoid throws. Let them bubble to `app/error.tsx`.
+
+</details>
+
+<details>
+<summary>Client Components</summary>
+
+- Client Components should call `app/api/**` endpoints for reads that are initiated in the browser after hydration or through user interaction.
+- Client-side fetch failures should be handled with local UI state such as `isLoading`, `error`, and retry actions.
+- Do not rely on `app/error.tsx` for `useEffect`, event handler, or normal browser fetch errors.
+- Mutations from client UI can keep using API Routes for now. Server Actions can be adopted later when the mutation flow is ready to be unified.
+
+</details>
+
+<details>
+<summary>Service Layer</summary>
+
+- Services are server-only modules and may call Supabase or other server-side data sources directly.
+- Services should return typed expected failures such as validation errors or not-found cases.
+- Services should throw unexpected infrastructure, permission, schema, and unknown runtime errors.
+- Services should not catch every error and convert all failures into `success: false`.
+
+</details>
+
+<details>
+<summary>API Routes</summary>
+
+- API Routes exist primarily for browser-facing access from Client Components.
+- API Routes translate service results into consistent HTTP responses and status codes.
+- Expected failures should map to explicit status codes such as `400`, `401`, `403`, `404`, and `409`.
+- Unexpected thrown errors should become `500` responses and be logged on the server.
+
+</details>
+
+<details>
+<summary>Current Project Mapping</summary>
+
+- Browser-driven event list refreshes and form flows belong on API Routes plus client state handling.
+- Page-level data such as event detail, category bootstrapping, and initial event lists belong on Server Components plus direct service calls.
+- This keeps the browser on HTTP boundaries while avoiding unnecessary server-to-server round trips inside the App Router.
+
+</details>
+
 ## Deploy Links
 
 [storybook](https://main--68415e7255ac6767cd35dc0c.chromatic.com)

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6 py-16">
+      <div className="max-w-md text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">404</p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-slate-900">Page not found</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          The requested resource could not be found. Try going back to the home page.
+        </p>
+        <Link
+          href="/"
+          className="mt-6 inline-flex rounded-full bg-slate-900 px-5 py-2 text-sm font-medium text-white transition hover:bg-slate-700"
+        >
+          Return home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,13 +1,25 @@
 import { CreateEventRequest, CreateEventResponse } from '@/dto/event/create-event.dto';
 import { EventDetailResponse } from '@/dto/event/event-detail.dto';
 import { EventListResponse } from '@/dto/event/event-list.dto';
-import { EventCategory, RegionListResponse } from '@/dto/event/shared-event.dto';
+import { EventCategory, EventDateFilter, RegionListResponse, RegionName } from '@/dto/event/shared-event.dto';
 import { UpdateEventRequest, UpdateEventResponse } from '@/dto/event/update-event.dto';
+import { ErrorResponseBody, isSerializedAppError, SerializedAppError } from '@/lib/errors/error-contract';
 
 export class ApiError extends Error {
-  constructor(message: string, public status: number, public endpoint: string) {
+  public readonly code: SerializedAppError['code'];
+  public readonly details?: unknown;
+
+  constructor(
+    message: string,
+    public status: number,
+    public endpoint: string,
+    code: SerializedAppError['code'] = 'INTERNAL',
+    details?: unknown
+  ) {
     super(message);
     this.name = 'ApiError';
+    this.code = code;
+    this.details = details;
   }
 }
 
@@ -17,6 +29,31 @@ class ApiClient {
 
   constructor(baseUrl: string = '') {
     this.baseUrl = baseUrl;
+  }
+
+  private extractSerializedError(errorBody: unknown): SerializedAppError | null {
+    if (!errorBody || typeof errorBody !== 'object') {
+      return null;
+    }
+
+    const body = errorBody as Partial<ErrorResponseBody> & {
+      error?: unknown;
+      message?: unknown;
+    };
+
+    if (isSerializedAppError(body.error)) {
+      return body.error;
+    }
+
+    if (typeof body.message === 'string') {
+      return {
+        code: 'INTERNAL',
+        message: body.message,
+        statusCode: 500,
+      };
+    }
+
+    return null;
   }
 
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
@@ -35,38 +72,47 @@ class ApiClient {
 
       if (!response.ok) {
         let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+        let serializedError: SerializedAppError | null = null;
 
         try {
           const errorBody = await response.json();
-          if (errorBody.message) {
-            errorMessage = errorBody.message;
-          } else if (errorBody.error) {
+          serializedError = this.extractSerializedError(errorBody);
+
+          if (serializedError) {
+            errorMessage = serializedError.message;
+          } else if (
+            errorBody &&
+            typeof errorBody === 'object' &&
+            'error' in errorBody &&
+            typeof errorBody.error === 'string'
+          ) {
             errorMessage = errorBody.error;
           }
         } catch {
-          // JSON 파싱 실패 시 기본 메시지 사용
+          // Keep the default error message when the response body is not JSON.
         }
 
-        // 에러를 throw하여 Error Boundary에서 처리되도록
-        throw new ApiError(errorMessage, response.status, endpoint);
+        throw new ApiError(
+          errorMessage,
+          response.status,
+          endpoint,
+          serializedError?.code ?? 'INTERNAL',
+          serializedError?.details
+        );
       }
 
-      let data: T;
       const contentType = response.headers.get('content-type');
 
       if (contentType && contentType.includes('application/json')) {
-        data = await response.json();
-      } else {
-        data = (await response.text()) as unknown as T;
+        return (await response.json()) as T;
       }
 
-      return data; // 성공 시 data만 반환
+      return (await response.text()) as unknown as T;
     } catch (error) {
       if (error instanceof ApiError) {
-        throw error; // ApiError는 그대로 재throw
+        throw error;
       }
 
-      // 네트워크 에러 등은 ApiError로 래핑
       throw new ApiError(error instanceof Error ? error.message : 'Unknown error', 500, endpoint);
     }
   }
@@ -125,10 +171,12 @@ export const apiClient = new ApiClient(getApiBaseUrl());
 export interface QueryParams {
   page?: number;
   pageSize?: number;
-  search?: string;
+  keyword?: string;
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
   category?: EventCategory['name'];
+  region?: RegionName;
+  date?: EventDateFilter;
 }
 
 export const EventsApi = {
@@ -157,10 +205,6 @@ export const EventsApi = {
   update: async (id: string, event: UpdateEventRequest): Promise<UpdateEventResponse> => {
     return apiClient.patch<UpdateEventResponse>(`/events/${id}`, event);
   },
-
-  /*   replace: async (id: string, event: CreateEventRequest): Promise<Event> => {
-    return apiClient.put<Event>(`/events/${id}`, event);
-  }, */
 
   delete: async (id: string): Promise<void> => {
     return apiClient.delete<void>(`/events/${id}`);

--- a/src/lib/errors/error-contract.ts
+++ b/src/lib/errors/error-contract.ts
@@ -1,0 +1,33 @@
+export type AppErrorCode =
+  | 'VALIDATION'
+  | 'DATABASE'
+  | 'NOT_FOUND'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'CONFLICT'
+  | 'INTERNAL';
+
+export type SerializedAppError = {
+  code: AppErrorCode;
+  message: string;
+  statusCode: number;
+  details?: unknown;
+  stack?: string;
+};
+
+export type ErrorResponseBody = {
+  error: SerializedAppError;
+};
+
+export function isSerializedAppError(value: unknown): value is SerializedAppError {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<SerializedAppError>;
+  return (
+    typeof candidate.code === 'string' &&
+    typeof candidate.message === 'string' &&
+    typeof candidate.statusCode === 'number'
+  );
+}

--- a/src/lib/errors/serviceErrors.server.ts
+++ b/src/lib/errors/serviceErrors.server.ts
@@ -1,13 +1,17 @@
+import { AppErrorCode, ErrorResponseBody } from './error-contract';
+
 export abstract class CustomError extends Error {
+  public readonly code: AppErrorCode;
   public readonly statusCode: number;
   public readonly details?: unknown;
 
-  constructor(message: string, statusCode: number, details?: unknown) {
+  constructor(message: string, code: AppErrorCode, statusCode: number, details?: unknown) {
     super(message);
+    this.code = code;
     this.statusCode = statusCode;
     this.details = details;
-    this.name = 'CustomError';
-    // Error.captureStackTrace가 있으면 사용 (Node.js 환경)
+    this.name = new.target.name;
+
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
@@ -16,95 +20,77 @@ export abstract class CustomError extends Error {
   toResponse(): CustomErrorSerialized {
     return {
       error: {
+        code: this.code,
         message: this.message,
         statusCode: this.statusCode,
-        //객체인지 체크...
         ...(this.details !== undefined ? { details: this.details } : undefined),
-        ...(process.env.NODE_ENV === 'development' && { stack: this.stack }),
+        ...(process.env.NODE_ENV === 'development' ? { stack: this.stack } : undefined),
       },
     };
   }
 
-  //추후 as const로 타입 대체 필요
-  //db 에러는 client에서 불필요함
   static fromCode(code: number, message: string, details?: unknown) {
     switch (code) {
       case 400:
         return new ValidationError(message, details);
+      case 401:
+        return new UnauthorizedError(message, details);
+      case 403:
+        return new ForbiddenError(message, details);
       case 404:
         return new NotFoundError(message, details);
+      case 409:
+        return new ConflictError(message, details);
       default:
         return new InternalError(message, details);
     }
   }
 }
 
-export type CustomErrorSerialized = {
-  error: {
-    message: string;
-    statusCode: number;
-    details?: unknown;
-    stack?: string;
-  };
-};
-
-/* 
-  - 내부에서만 다뤄야 하는 Validation에러와 유저에게 보여줘야하는 에러가 나뉨
-  - db column명 <=> be property명 매핑 문제는 client에게 x
-  - 클라이언트에게 요청 받은 데이터의 validation 에러는 o
-  - 클라이언트에게 응답하는 데이터의 validation 에러는?
-*/
+export type CustomErrorSerialized = ErrorResponseBody;
 
 export class ValidationError extends CustomError {
   constructor(message: string, details?: unknown, statusCode: number = 400) {
-    super(message, statusCode, details);
-    this.name = 'ValidationError';
+    super(message, 'VALIDATION', statusCode, details);
   }
 }
 
 export class DatabaseError extends CustomError {
   constructor(message: string, details?: unknown, statusCode: number = 500) {
-    super(message, statusCode, details);
-    this.name = 'DatabaseError';
+    super(message, 'DATABASE', statusCode, details);
   }
 }
 
 export class NotFoundError extends CustomError {
   constructor(message: string = 'Resource not found', details?: unknown) {
-    super(message, 404, details);
-    this.name = 'NotFoundError';
+    super(message, 'NOT_FOUND', 404, details);
   }
 }
 
 export class UnauthorizedError extends CustomError {
   constructor(message: string = 'Unauthorized', details?: unknown) {
-    super(message, 401, details);
-    this.name = 'UnauthorizedError';
+    super(message, 'UNAUTHORIZED', 401, details);
   }
 }
 
 export class ForbiddenError extends CustomError {
   constructor(message: string = 'Forbidden', details?: unknown) {
-    super(message, 403, details);
-    this.name = 'ForbiddenError';
+    super(message, 'FORBIDDEN', 403, details);
   }
 }
 
 export class ConflictError extends CustomError {
   constructor(message: string = 'Resource conflict', details?: unknown) {
-    super(message, 409, details);
-    this.name = 'ConflictError';
+    super(message, 'CONFLICT', 409, details);
   }
 }
 
 export class InternalError extends CustomError {
   constructor(message: string = 'Internal server error', details?: unknown) {
-    super(message, 500, details);
-    this.name = 'InternalError';
+    super(message, 'INTERNAL', 500, details);
   }
 }
 
-// 에러 타입 가드 헬퍼 함수들
 export const isCustomError = (error: unknown): error is CustomError => {
-  return error instanceof CustomError || (error instanceof Error && error.name === 'CustomError');
+  return error instanceof CustomError;
 };

--- a/src/services/type.ts
+++ b/src/services/type.ts
@@ -1,4 +1,4 @@
-import { CustomErrorSerialized } from '@/lib/errors/serviceErrors.server';
+import { SerializedAppError } from '@/lib/errors/error-contract';
 
 export type Result<D, E = Error> =
   | {
@@ -6,4 +6,4 @@ export type Result<D, E = Error> =
       data: D;
     }
   | { success: false; error: E };
-export type ServiceResult<D> = Result<D, CustomErrorSerialized['error']>;
+export type ServiceResult<D> = Result<D, SerializedAppError>;


### PR DESCRIPTION
## Summary
- document the project error handling policy in README
- add shared serialized error contracts for services and API responses
- add app-level not-found UI and align shared client parsing with the new contract

## Verification
- npx tsc --noEmit
- npm run lint