### PR TITLE
refactor: surface expected server fetch errors in UI

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -41,6 +41,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<Mai
         keyword: resolvedSearchParams.keyword,
       });
   const initialSectionData = initialSectionResponse.success ? initialSectionResponse.data : null;
+  const initialSectionErrorMessage = initialSectionResponse.success ? null : initialSectionResponse.error.message;
   const initialSearchKey = JSON.stringify({
     page: resolvedPage,
     category: resolvedSearchParams.category,
@@ -59,6 +60,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<Mai
           <Suspense fallback={null}>
             <EventListSection
               initialData={initialSectionData}
+              initialErrorMessage={initialSectionErrorMessage}
               initialSearchKey={initialSearchKey}
               latestPageSize={HOME_LATEST_EVENT_PAGE_SIZE}
               latestGridClassName={HOME_LATEST_EVENT_GRID_STYLES}

--- a/src/components/event/eventFilter/EventFilterContainer.tsx
+++ b/src/components/event/eventFilter/EventFilterContainer.tsx
@@ -1,9 +1,23 @@
+import { AlertCircle } from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { categoryService } from '@/services/Category';
 import EventFilter from './EventFilter';
 
 export default async function EventFilterContainer() {
   const response = await categoryService.getCateogires();
-  if (!response.success) return <div>이벤트 카테고리 fetching 실패</div>;
-  const { data: categories } = response;
-  return <EventFilter categories={categories} />;
+
+  if (!response.success) {
+    return (
+      <div className="px-4 pb-3 sm:px-6 lg:px-8">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>필터를 불러오지 못했습니다.</AlertTitle>
+          <AlertDescription>{response.error.message}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return <EventFilter categories={response.data} />;
 }

--- a/src/components/event/eventList/EventListSection.tsx
+++ b/src/components/event/eventList/EventListSection.tsx
@@ -6,7 +6,9 @@ import { useSearchParams } from 'next/navigation';
 import type { EventListResponse } from '@/dto/event/event-list.dto';
 import type { EventDateFilter, EventCategory, RegionName } from '@/dto/event/shared-event.dto';
 import ExploreFeedSection, { ExploreSectionBadge, ExploreSectionCopy } from '@/components/event/explore/ExploreFeedSection';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { ApiError, EventsApi } from '@/lib/api-client';
+import { AlertCircle } from 'lucide-react';
 import { formatEventDateFilterLabel } from '@/utils/eventDateFilter';
 import EventList from './EventList';
 import EventPagination from '../EventPagination';
@@ -16,6 +18,7 @@ const DEFAULT_EVENT_PAGE_SIZE = 5;
 
 type EventListSectionProps = {
   initialData?: EventListResponse | null;
+  initialErrorMessage?: string | null;
   initialSearchKey: string;
   latestPageSize: number;
   latestGridClassName?: string;
@@ -92,6 +95,7 @@ function getExploreSectionBadges(params: EventListQueryState): ExploreSectionBad
 
 export default function EventListSection({
   initialData,
+  initialErrorMessage,
   initialSearchKey,
   latestPageSize,
   latestGridClassName,
@@ -104,12 +108,12 @@ export default function EventListSection({
 
   const [data, setData] = useState<EventListResponse | null>(initialData ?? null);
   const [isLoading, setIsLoading] = useState(currentSearchKey !== initialSearchKey && !initialData);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(initialErrorMessage ?? null);
 
   useEffect(() => {
     if (currentSearchKey === initialSearchKey) {
       setData(initialData ?? null);
-      setErrorMessage(null);
+      setErrorMessage(initialErrorMessage ?? null);
       setIsLoading(false);
       return;
     }
@@ -156,7 +160,7 @@ export default function EventListSection({
     fetchEvents();
 
     return () => controller.abort();
-  }, [currentSearchKey, initialData, initialSearchKey, pageSize, queryState]);
+  }, [currentSearchKey, initialData, initialErrorMessage, initialSearchKey, pageSize, queryState]);
 
   const sectionCopy = getExploreSectionCopy(queryState);
   const sectionBadges = getExploreSectionBadges(queryState);
@@ -189,7 +193,13 @@ function EventListSectionContent({
   queryState: EventListQueryState;
 }) {
   if (errorMessage) {
-    return <div>{errorMessage}</div>;
+    return (
+      <Alert variant="destructive" className="rounded-[28px] border border-red-200 bg-white/90 p-6">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>이벤트 목록을 불러오지 못했습니다.</AlertTitle>
+        <AlertDescription>{errorMessage}</AlertDescription>
+      </Alert>
+    );
   }
 
   if (!data) {


### PR DESCRIPTION
## Summary
- show expected category fetch failures in the filter container UI
- pass initial server-fetch error messages into the main event list section
- render expected list-loading failures with a dedicated alert instead of silently falling back

## Verification
- npx tsc --noEmit
- npm run lint